### PR TITLE
feat: add SSH support for remote Claude sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,12 @@
 PORT=3001
 #Frontend port
 VITE_PORT=5173
+
+# Optional SSH configuration for remote Claude sessions
+# When provided, UI will send these credentials to the server
+# to execute Claude CLI on the remote host
+VITE_SSH_HOST=
+VITE_SSH_PORT=
+VITE_SSH_USER=
+VITE_SSH_PASSWORD=
+VITE_SSH_PRIVATE_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "multer": "^2.0.1",
         "node-fetch": "^2.7.0",
         "node-pty": "^1.1.0-beta34",
+        "node-ssh": "^13.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
@@ -2223,6 +2224,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/attr-accept": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
@@ -2318,6 +2328,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/better-sqlite3": {
@@ -2494,6 +2513,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -3026,6 +3054,20 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/crelt": {
@@ -4299,6 +4341,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4540,6 +4594,21 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -5511,6 +5580,13 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -5694,6 +5770,23 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-ssh": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-13.2.1.tgz",
+      "integrity": "sha512-rfl4GWMygQfzlExPkQ2LWyya5n2jOBm5vhEnup+4mdw7tQhNpJWbP5ldr09Jfj93k5SfY5lxcn8od5qrQ/6mBg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "make-dir": "^3.1.0",
+        "sb-promise-queue": "^2.1.0",
+        "sb-scandir": "^3.1.0",
+        "shell-escape": "^0.2.0",
+        "ssh2": "^1.14.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -6672,6 +6765,27 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sb-promise-queue": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sb-promise-queue/-/sb-promise-queue-2.1.1.tgz",
+      "integrity": "sha512-qXfdcJQMxMljxmPprn4Q4hl3pJmoljSCzUvvEBa9Kscewnv56n0KqrO6yWSrGLOL9E021wcGdPa39CHGKA6G0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sb-scandir": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/sb-scandir/-/sb-scandir-3.1.1.tgz",
+      "integrity": "sha512-Q5xiQMtoragW9z8YsVYTAZcew+cRzdVBefPbb9theaIKw6cBo34WonP9qOCTKgyAmn/Ch5gmtAxT/krUgMILpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sb-promise-queue": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6685,7 +6799,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7063,6 +7176,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-escape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==",
+      "license": "MIT"
     },
     "node_modules/shell-quote": {
       "version": "1.8.3",
@@ -7671,6 +7790,23 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/ssri": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
@@ -8238,6 +8374,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "multer": "^2.0.1",
     "node-fetch": "^2.7.0",
     "node-pty": "^1.1.0-beta34",
+    "node-ssh": "^13.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",

--- a/server/claude-cli.js
+++ b/server/claude-cli.js
@@ -3,15 +3,18 @@ import crossSpawn from 'cross-spawn';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import { NodeSSH } from 'node-ssh';
 
 // Use cross-spawn on Windows for better command execution
 const spawnFunction = process.platform === 'win32' ? crossSpawn : spawn;
 
-let activeClaudeProcesses = new Map(); // Track active processes by session ID
+// Track active sessions (local or remote) by session ID
+// Map<sessionId, { type: 'local', process: ChildProcess } | { type: 'ssh', ssh: NodeSSH, channel: any }>
+let activeClaudeProcesses = new Map();
 
 async function spawnClaude(command, options = {}, ws) {
   return new Promise(async (resolve, reject) => {
-    const { sessionId, projectPath, cwd, resume, toolsSettings, permissionMode, images } = options;
+    const { sessionId, projectPath, cwd, resume, toolsSettings, permissionMode, images, ssh: sshConfig } = options;
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     
@@ -38,47 +41,57 @@ async function spawnClaude(command, options = {}, ws) {
     const workingDir = cwd || process.cwd();
     
     // Handle images by saving them to temporary files and passing paths to Claude
-    const tempImagePaths = [];
-    let tempDir = null;
+    const tempImagePaths = []; // paths used in command (local or remote)
+    let tempDir = null; // local temp dir
+    let remoteTempDir = null; // remote temp dir when using ssh
+    const localImagePaths = []; // used for uploading when using ssh
     if (images && images.length > 0) {
       try {
-        // Create temp directory in the project directory so Claude can access it
-        tempDir = path.join(workingDir, '.tmp', 'images', Date.now().toString());
+        const timestamp = Date.now().toString();
+        if (sshConfig) {
+          // When using SSH, create temp dir locally then upload to remote cwd
+          tempDir = path.join(os.tmpdir(), 'claude-ssh', timestamp);
+          remoteTempDir = path.posix.join(workingDir.replace(/\\/g, '/'), '.tmp', 'images', timestamp);
+        } else {
+          // Create temp directory in the project directory so Claude can access it
+          tempDir = path.join(workingDir, '.tmp', 'images', timestamp);
+        }
         await fs.mkdir(tempDir, { recursive: true });
-        
+
         // Save each image to a temp file
         for (const [index, image] of images.entries()) {
-          // Extract base64 data and mime type
           const matches = image.data.match(/^data:([^;]+);base64,(.+)$/);
           if (!matches) {
             console.error('Invalid image data format');
             continue;
           }
-          
+
           const [, mimeType, base64Data] = matches;
           const extension = mimeType.split('/')[1] || 'png';
           const filename = `image_${index}.${extension}`;
-          const filepath = path.join(tempDir, filename);
-          
-          // Write base64 data to file
-          await fs.writeFile(filepath, Buffer.from(base64Data, 'base64'));
-          tempImagePaths.push(filepath);
+          const localPath = path.join(tempDir, filename);
+          await fs.writeFile(localPath, Buffer.from(base64Data, 'base64'));
+
+          if (sshConfig) {
+            const remotePath = path.posix.join(remoteTempDir, filename);
+            localImagePaths.push({ local: localPath, remote: remotePath });
+            tempImagePaths.push(remotePath);
+          } else {
+            tempImagePaths.push(localPath);
+          }
         }
-        
-        // Include the full image paths in the prompt for Claude to reference
-        // Only modify the command if we actually have images and a command
+
         if (tempImagePaths.length > 0 && command && command.trim()) {
           const imageNote = `\n\n[Images provided at the following paths:]\n${tempImagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n')}`;
           const modifiedCommand = command + imageNote;
-          
+
           // Update the command in args - now that --print and command are separate
           const printIndex = args.indexOf('--print');
           if (printIndex !== -1 && printIndex + 1 < args.length && args[printIndex + 1] === command) {
             args[printIndex + 1] = modifiedCommand;
           }
         }
-        
-        
+
       } catch (error) {
         console.error('Error processing images for Claude:', error);
       }
@@ -234,151 +247,174 @@ async function spawnClaude(command, options = {}, ws) {
     console.log('Session info - Input sessionId:', sessionId, 'Resume:', resume);
     console.log('🔍 Full command args:', JSON.stringify(args, null, 2));
     console.log('🔍 Final Claude command will be: claude ' + args.join(' '));
-    
-    const claudeProcess = spawnFunction('claude', args, {
-      cwd: workingDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env } // Inherit all environment variables
-    });
-    
-    // Attach temp file info to process for cleanup later
-    claudeProcess.tempImagePaths = tempImagePaths;
-    claudeProcess.tempDir = tempDir;
-    
-    // Store process reference for potential abort
     const processKey = capturedSessionId || sessionId || Date.now().toString();
-    activeClaudeProcesses.set(processKey, claudeProcess);
-    
-    // Handle stdout (streaming JSON responses)
-    claudeProcess.stdout.on('data', (data) => {
+
+    const handleStdout = (data) => {
       const rawOutput = data.toString();
       console.log('📤 Claude CLI stdout:', rawOutput);
-      
       const lines = rawOutput.split('\n').filter(line => line.trim());
-      
       for (const line of lines) {
         try {
           const response = JSON.parse(line);
           console.log('📄 Parsed JSON response:', response);
-          
-          // Capture session ID if it's in the response
           if (response.session_id && !capturedSessionId) {
             capturedSessionId = response.session_id;
             console.log('📝 Captured session ID:', capturedSessionId);
-            
-            // Update process key with captured session ID
-            if (processKey !== capturedSessionId) {
+            const existing = activeClaudeProcesses.get(processKey);
+            if (existing && processKey !== capturedSessionId) {
               activeClaudeProcesses.delete(processKey);
-              activeClaudeProcesses.set(capturedSessionId, claudeProcess);
+              activeClaudeProcesses.set(capturedSessionId, existing);
             }
-            
-            // Send session-created event only once for new sessions
             if (!sessionId && !sessionCreatedSent) {
               sessionCreatedSent = true;
-              ws.send(JSON.stringify({
-                type: 'session-created',
-                sessionId: capturedSessionId
-              }));
+              ws.send(JSON.stringify({ type: 'session-created', sessionId: capturedSessionId }));
             }
           }
-          
-          // Send parsed response to WebSocket
-          ws.send(JSON.stringify({
-            type: 'claude-response',
-            data: response
-          }));
+          ws.send(JSON.stringify({ type: 'claude-response', data: response }));
         } catch (parseError) {
           console.log('📄 Non-JSON response:', line);
-          // If not JSON, send as raw text
-          ws.send(JSON.stringify({
-            type: 'claude-output',
-            data: line
-          }));
+          ws.send(JSON.stringify({ type: 'claude-output', data: line }));
         }
       }
-    });
-    
-    // Handle stderr
-    claudeProcess.stderr.on('data', (data) => {
+    };
+
+    const handleStderr = (data) => {
       console.error('Claude CLI stderr:', data.toString());
-      ws.send(JSON.stringify({
-        type: 'claude-error',
-        error: data.toString()
-      }));
-    });
-    
-    // Handle process completion
-    claudeProcess.on('close', async (code) => {
-      console.log(`Claude CLI process exited with code ${code}`);
-      
-      // Clean up process reference
-      const finalSessionId = capturedSessionId || sessionId || processKey;
-      activeClaudeProcesses.delete(finalSessionId);
-      
-      ws.send(JSON.stringify({
-        type: 'claude-complete',
-        exitCode: code,
-        isNewSession: !sessionId && !!command // Flag to indicate this was a new session
-      }));
-      
-      // Clean up temporary image files if any
-      if (claudeProcess.tempImagePaths && claudeProcess.tempImagePaths.length > 0) {
-        for (const imagePath of claudeProcess.tempImagePaths) {
-          await fs.unlink(imagePath).catch(err => 
-            console.error(`Failed to delete temp image ${imagePath}:`, err)
-          );
+      ws.send(JSON.stringify({ type: 'claude-error', error: data.toString() }));
+    };
+
+    if (sshConfig) {
+      try {
+        const ssh = new NodeSSH();
+        await ssh.connect(sshConfig);
+
+        if (localImagePaths.length > 0) {
+          await ssh.execCommand(`mkdir -p ${remoteTempDir}`);
+          for (const img of localImagePaths) {
+            await ssh.putFile(img.local, img.remote);
+          }
         }
-        if (claudeProcess.tempDir) {
-          await fs.rm(claudeProcess.tempDir, { recursive: true, force: true }).catch(err => 
-            console.error(`Failed to delete temp directory ${claudeProcess.tempDir}:`, err)
-          );
+
+        activeClaudeProcesses.set(processKey, { type: 'ssh', ssh, channel: null });
+
+        const result = await ssh.exec('claude', args, {
+          cwd: workingDir,
+          stream: 'both',
+          onChannel: (channel) => {
+            const info = activeClaudeProcesses.get(processKey);
+            if (info) info.channel = channel;
+          },
+          onStdout: handleStdout,
+          onStderr: handleStderr,
+        });
+
+        const finalSessionId = capturedSessionId || sessionId || processKey;
+        activeClaudeProcesses.delete(finalSessionId);
+
+        ws.send(JSON.stringify({
+          type: 'claude-complete',
+          exitCode: result.code,
+          isNewSession: !sessionId && !!command
+        }));
+
+        if (localImagePaths.length > 0) {
+          for (const img of localImagePaths) {
+            await fs.unlink(img.local).catch(err => console.error(`Failed to delete temp image ${img.local}:`, err));
+          }
+          if (tempDir) {
+            await fs.rm(tempDir, { recursive: true, force: true }).catch(err => console.error(`Failed to delete temp dir ${tempDir}:`, err));
+          }
+          if (remoteTempDir) {
+            await ssh.execCommand(`rm -rf ${remoteTempDir}`).catch(err => console.error(`Failed to delete remote temp dir ${remoteTempDir}:`, err.message));
+          }
         }
+
+        ssh.dispose();
+        if (result.code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Claude CLI exited with code ${result.code}`));
+        }
+      } catch (error) {
+        console.error('Claude CLI process error:', error);
+        activeClaudeProcesses.delete(processKey);
+        ws.send(JSON.stringify({ type: 'claude-error', error: error.message }));
+        reject(error);
       }
-      
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Claude CLI exited with code ${code}`));
-      }
-    });
-    
-    // Handle process errors
-    claudeProcess.on('error', (error) => {
-      console.error('Claude CLI process error:', error);
-      
-      // Clean up process reference on error
-      const finalSessionId = capturedSessionId || sessionId || processKey;
-      activeClaudeProcesses.delete(finalSessionId);
-      
-      ws.send(JSON.stringify({
-        type: 'claude-error',
-        error: error.message
-      }));
-      
-      reject(error);
-    });
-    
-    // Handle stdin for interactive mode
-    if (command) {
-      // For --print mode with arguments, we don't need to write to stdin
-      claudeProcess.stdin.end();
     } else {
-      // For interactive mode, we need to write the command to stdin if provided later
-      // Keep stdin open for interactive session
-      if (command !== undefined) {
-        claudeProcess.stdin.write(command + '\n');
+      const claudeProcess = spawnFunction('claude', args, {
+        cwd: workingDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env }
+      });
+
+      claudeProcess.tempImagePaths = tempImagePaths;
+      claudeProcess.tempDir = tempDir;
+      activeClaudeProcesses.set(processKey, { type: 'local', process: claudeProcess });
+
+      claudeProcess.stdout.on('data', handleStdout);
+      claudeProcess.stderr.on('data', handleStderr);
+
+      claudeProcess.on('close', async (code) => {
+        console.log(`Claude CLI process exited with code ${code}`);
+        const finalSessionId = capturedSessionId || sessionId || processKey;
+        activeClaudeProcesses.delete(finalSessionId);
+        ws.send(JSON.stringify({
+          type: 'claude-complete',
+          exitCode: code,
+          isNewSession: !sessionId && !!command
+        }));
+
+        if (claudeProcess.tempImagePaths && claudeProcess.tempImagePaths.length > 0) {
+          for (const imagePath of claudeProcess.tempImagePaths) {
+            await fs.unlink(imagePath).catch(err => console.error(`Failed to delete temp image ${imagePath}:`, err));
+          }
+          if (claudeProcess.tempDir) {
+            await fs.rm(claudeProcess.tempDir, { recursive: true, force: true }).catch(err => console.error(`Failed to delete temp directory ${claudeProcess.tempDir}:`, err));
+          }
+        }
+
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Claude CLI exited with code ${code}`));
+        }
+      });
+
+      claudeProcess.on('error', (error) => {
+        console.error('Claude CLI process error:', error);
+        const finalSessionId = capturedSessionId || sessionId || processKey;
+        activeClaudeProcesses.delete(finalSessionId);
+        ws.send(JSON.stringify({ type: 'claude-error', error: error.message }));
+        reject(error);
+      });
+
+      if (command) {
         claudeProcess.stdin.end();
+      } else {
+        if (command !== undefined) {
+          claudeProcess.stdin.write(command + '\n');
+          claudeProcess.stdin.end();
+        }
       }
-      // If no command provided, stdin stays open for interactive use
     }
   });
 }
 
 function abortClaudeSession(sessionId) {
-  const process = activeClaudeProcesses.get(sessionId);
-  if (process) {
+  const entry = activeClaudeProcesses.get(sessionId);
+  if (entry) {
     console.log(`🛑 Aborting Claude session: ${sessionId}`);
-    process.kill('SIGTERM');
+    try {
+      if (entry.type === 'ssh' && entry.channel) {
+        entry.channel.signal('TERM');
+        entry.ssh.dispose();
+      } else if (entry.type === 'local' && entry.process) {
+        entry.process.kill('SIGTERM');
+      }
+    } catch (err) {
+      console.error('Error aborting session:', err);
+    }
     activeClaudeProcesses.delete(sessionId);
     return true;
   }

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1183,6 +1183,19 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
   const [isLoadingSessionMessages, setIsLoadingSessionMessages] = useState(false);
   const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
   const [messagesOffset, setMessagesOffset] = useState(0);
+
+  const sshConfig = useMemo(() => {
+    const host = import.meta.env.VITE_SSH_HOST;
+    if (!host) return null;
+    const cfg = {
+      host,
+      username: import.meta.env.VITE_SSH_USER
+    };
+    if (import.meta.env.VITE_SSH_PORT) cfg.port = parseInt(import.meta.env.VITE_SSH_PORT);
+    if (import.meta.env.VITE_SSH_PASSWORD) cfg.password = import.meta.env.VITE_SSH_PASSWORD;
+    if (import.meta.env.VITE_SSH_PRIVATE_KEY) cfg.privateKey = import.meta.env.VITE_SSH_PRIVATE_KEY;
+    return cfg;
+  }, []);
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
   const [totalMessages, setTotalMessages] = useState(0);
   const MESSAGES_PER_PAGE = 20;
@@ -2777,18 +2790,22 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
       });
     } else {
       // Send Claude command (existing code)
+      const claudeOptions = {
+        projectPath: selectedProject.path,
+        cwd: selectedProject.fullPath,
+        sessionId: currentSessionId,
+        resume: !!currentSessionId,
+        toolsSettings: toolsSettings,
+        permissionMode: permissionMode,
+        images: uploadedImages
+      };
+      if (sshConfig) {
+        claudeOptions.ssh = sshConfig;
+      }
       sendMessage({
         type: 'claude-command',
         command: input,
-        options: {
-          projectPath: selectedProject.path,
-          cwd: selectedProject.fullPath,
-          sessionId: currentSessionId,
-          resume: !!currentSessionId,
-          toolsSettings: toolsSettings,
-          permissionMode: permissionMode,
-          images: uploadedImages // Pass images to backend
-        }
+        options: claudeOptions
       });
     }
 


### PR DESCRIPTION
## Summary
- add optional SSH execution path for Claude CLI, including remote image upload and session abort
- allow UI to send SSH credentials from environment variables
- document SSH settings in `.env.example`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aef65eeee88320ab7221f21f8ab121